### PR TITLE
chore(deps): configure dependabot to use semver PR titles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
     groups:
       dev-dependencies:
         patterns:
@@ -23,3 +25,5 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"


### PR DESCRIPTION
## Summary
- Add `commit-message` prefix configuration to Dependabot
- Both npm and github-actions ecosystems now use `chore(deps):` prefix
- Future Dependabot PRs will follow conventional commit format

## Test plan
- [ ] Verify next Dependabot PR uses the new title format