### PR TITLE
chore: rebrand from StringRay to Stringly-Typed

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,13 +16,13 @@ assignees: ''
 
 ## Steps to reproduce
 
-1. Configure StringRay with: `...`
+1. Configure Stringly-Typed with: `...`
 2. Run on files: `...`
 3. See error: `...`
 
 ## Environment
 
-- **StringRay Version:** `v1.0.0`
+- **Stringly-Typed Version:** `v1.0.0`
 - **Runner:** `ubuntu-latest` / `windows-latest` / `macos-latest`
 - **Files:** What file types are you scanning?
 
@@ -31,8 +31,8 @@ assignees: ''
 **Any other info that might help debug this**
 
 ```yaml
-# Your StringRay configuration
-- uses: ddnetters/stringray@v1
+# Your Stringly-Typed configuration
+- uses: ddnetters/stringly-typed@v1
   with:
     files: 'src/**/*.js'
     checker: 'char_count'

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -20,7 +20,7 @@ assignees: ''
 
 ```yaml
 # Example configuration
-- uses: ddnetters/stringray@v1
+- uses: ddnetters/stringly-typed@v1
   with:
     files: 'src/**/*.js'
     checker: 'new-feature'

--- a/.github/PULL_REQUEST_TITLE_CONVENTION.md
+++ b/.github/PULL_REQUEST_TITLE_CONVENTION.md
@@ -1,6 +1,6 @@
 # 🏷️ PR Title Convention
 
-StringRay uses automated releases based on PR titles. Please format your PR titles using conventional commits:
+Stringly-Typed uses automated releases based on PR titles. Please format your PR titles using conventional commits:
 
 ## 📋 Format
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-# 🌊 StringRay Pull Request
+# 🎯 Stringly-Typed Pull Request
 
 > **📋 Important:** Use conventional commit format in PR title for auto-releases!  
 > See [PR Title Convention](.github/PULL_REQUEST_TITLE_CONVENTION.md) for examples.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
           npm ci
           npm run build
       
-      - name: 🔦 Test StringRay on itself
+      - name: 🔦 Test Stringly-Typed on itself
         uses: ./
         with:
           files: 'src/**/*.ts'
@@ -174,7 +174,7 @@ See the full changelog for details of what's included in this release.
 ## 🚀 Quick Start
 
 \`\`\`yaml
-- uses: ddnetters/stringray@\$VERSION
+- uses: ddnetters/stringly-typed@\$VERSION
   with:
     files: 'src/**/*.{js,ts,md}'
     checker: 'char_count'
@@ -193,7 +193,7 @@ EOF
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ needs.validate-release.outputs.version }}
-          name: 🌊 StringRay ${{ needs.validate-release.outputs.version }}
+          name: 🎯 Stringly-Typed ${{ needs.validate-release.outputs.version }}
           body_path: release-notes.md
           draft: false
           prerelease: ${{ needs.validate-release.outputs.is-prerelease }}
@@ -235,12 +235,12 @@ EOF
             pkg.keywords = ['github-action', 'string-validation', 'code-quality', 'linting'];
             pkg.repository = {
               type: 'git',
-              url: 'https://github.com/ddnetters/stringray.git'
+              url: 'https://github.com/ddnetters/stringly-typed.git'
             };
             pkg.bugs = {
-              url: 'https://github.com/ddnetters/stringray/issues'
+              url: 'https://github.com/ddnetters/stringly-typed/issues'
             };
-            pkg.homepage = 'https://github.com/ddnetters/stringray#readme';
+            pkg.homepage = 'https://github.com/ddnetters/stringly-typed#readme';
             require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2));
           "
       
@@ -300,17 +300,17 @@ EOF
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 category_slug: "announcements",
-                title: `🌊 StringRay ${version} Released!`,
+                title: `🎯 Stringly-Typed ${version} Released!`,
                 body: `
-            ## 🎉 StringRay ${version} is now available!
+            ## 🎉 Stringly-Typed ${version} is now available!
 
             **Shine a light on your code's communication with this latest release.**
 
             ### 🚀 Quick Start
 
             \`\`\`yaml
-            - name: 🔦 Scan with StringRay
-              uses: ddnetters/stringray@${version}
+            - name: 🔦 Scan with Stringly-Typed
+              uses: ddnetters/stringly-typed@${version}
               with:
                 files: 'src/**/*.{js,ts,md}'
                 checker: 'char_count'
@@ -327,7 +327,7 @@ EOF
 
             ---
 
-            **🔦 Happy string scanning! 🌊**
+            **🔦 Happy string scanning! 🎯**
                 `
               });
               console.log("✅ Created release discussion");

--- a/.github/workflows/test-stringly-typed.yml
+++ b/.github/workflows/test-stringly-typed.yml
@@ -1,4 +1,4 @@
-name: Test StringRay
+name: Test Stringly-Typed
 on: 
   push:
     branches: [ main ]
@@ -6,7 +6,7 @@ on:
     branches: [ main ]
 
 jobs:
-  test-stringray:
+  test-stringly-typed:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -24,8 +24,8 @@ jobs:
       - name: Build action
         run: npm run build
         
-      - name: Test StringRay Action
-        id: stringray
+      - name: Test Stringly-Typed Action
+        id: stringly-typed
         uses: ./
         with:
           files: 'test-strings.js'
@@ -34,11 +34,11 @@ jobs:
           checker-options: '{}'
           decider-options: '{"minValidRatio": 0.8}'
           
-      - name: Show StringRay Results
+      - name: Show Stringly-Typed Results
         run: |
-          echo "Results: ${{ steps.stringray.outputs.results }}"
-          echo "Summary: ${{ steps.stringray.outputs.summary }}"
-          echo "Pass: ${{ steps.stringray.outputs.pass }}"
+          echo "Results: ${{ steps.stringly-typed.outputs.results }}"
+          echo "Summary: ${{ steps.stringly-typed.outputs.summary }}"
+          echo "Pass: ${{ steps.stringly-typed.outputs.pass }}"
           
       - name: List files being processed
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: 🌊 StringRay CI
+name: 🎯 Stringly-Typed CI
 
 on:
   push:
@@ -63,7 +63,7 @@ jobs:
     - name: Build
       run: npm run build
     
-    - name: 🔦 Test StringRay Action
+    - name: 🔦 Test Stringly-Typed Action
       uses: ./
       with:
         files: 'src/**/*.ts'

--- a/.gitignore
+++ b/.gitignore
@@ -152,7 +152,7 @@ pids
 ehthumbs.db
 Thumbs.db
 
-# StringRay specific
+# Stringly-Typed specific
 .string-validation-cache
 util-scripts/
 

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -45,7 +45,7 @@
       "@semantic-release/changelog",
       {
         "changelogFile": "CHANGELOG.md",
-        "changelogTitle": "# 📊 Changelog\n\nAll notable changes to StringRay are automatically documented here.\n\nThis project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).\n\nReleases are automatically created when PRs with conventional commit titles are merged to main:\n- `feat:` → Minor version bump (new features)\n- `fix:` → Patch version bump (bug fixes) \n- `docs:`, `chore:`, `style:`, etc. → Patch version bump\n- `BREAKING CHANGE` or `!` → Major version bump\n"
+        "changelogTitle": "# 📊 Changelog\n\nAll notable changes to Stringly-Typed are automatically documented here.\n\nThis project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).\n\nReleases are automatically created when PRs with conventional commit titles are merged to main:\n- `feat:` → Minor version bump (new features)\n- `fix:` → Patch version bump (bug fixes) \n- `docs:`, `chore:`, `style:`, etc. → Patch version bump\n- `BREAKING CHANGE` or `!` → Major version bump\n"
       }
     ],
     [
@@ -58,8 +58,8 @@
       "@semantic-release/github",
       {
         "releasedLabels": ["released"],
-        "releaseNameTemplate": "🌊 StringRay ${nextRelease.version}",
-        "releaseBodyTemplate": "## 🚀 Auto Release\n\n### 📋 What's Changed\n\n${nextRelease.notes}\n\n### 🔦 Quick Start\n\n```yaml\n- uses: ddnetters/stringray@${nextRelease.version}\n  with:\n    files: 'src/**/*.{js,ts,md}'\n    checker: 'grammar'\n    decider: 'threshold'\n```\n\n**Full Changelog**: https://github.com/ddnetters/stringray/compare/${lastRelease.gitTag}...${nextRelease.gitTag}"
+        "releaseNameTemplate": "🌊 Stringly-Typed ${nextRelease.version}",
+        "releaseBodyTemplate": "## 🚀 Auto Release\n\n### 📋 What's Changed\n\n${nextRelease.notes}\n\n### 🔦 Quick Start\n\n```yaml\n- uses: ddnetters/stringly-typed@${nextRelease.version}\n  with:\n    files: 'src/**/*.{js,ts,md}'\n    checker: 'grammar'\n    decider: 'threshold'\n```\n\n**Full Changelog**: https://github.com/ddnetters/stringly-typed/compare/${lastRelease.gitTag}...${nextRelease.gitTag}"
       }
     ],
     [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 📊 Changelog
 
-All notable changes to StringRay are automatically documented here.
+All notable changes to Stringly-Typed are automatically documented here.
 
 This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
@@ -11,37 +11,37 @@ Releases are automatically created when PRs with conventional commit titles are 
 - `BREAKING CHANGE` or `!` → Major version bump
 
 
-## [1.0.2](https://github.com/ddnetters/stringray/compare/v1.0.1...v1.0.2) (2026-01-28)
+## [1.0.2](https://github.com/ddnetters/stringly-typed/compare/v1.0.1...v1.0.2) (2026-01-28)
 
 ### 📚 Documentation
 
-* streamline README for faster developer onboarding ([#19](https://github.com/ddnetters/stringray/issues/19)) ([11685df](https://github.com/ddnetters/stringray/commit/11685df672636b2093dc0d65e19dcdcbd6b607fb))
+* streamline README for faster developer onboarding ([#19](https://github.com/ddnetters/stringly-typed/issues/19)) ([11685df](https://github.com/ddnetters/stringly-typed/commit/11685df672636b2093dc0d65e19dcdcbd6b607fb))
 
-## [1.0.1](https://github.com/ddnetters/stringray/compare/v1.0.0...v1.0.1) (2026-01-28)
+## [1.0.1](https://github.com/ddnetters/stringly-typed/compare/v1.0.0...v1.0.1) (2026-01-28)
 
 ### ♻️ Refactoring
 
-* remove Grammar Checker ([#18](https://github.com/ddnetters/stringray/issues/18)) ([3b9b86c](https://github.com/ddnetters/stringray/commit/3b9b86ccdf2118ab00418aa3d8a83f1eaa4511b6))
+* remove Grammar Checker ([#18](https://github.com/ddnetters/stringly-typed/issues/18)) ([3b9b86c](https://github.com/ddnetters/stringly-typed/commit/3b9b86ccdf2118ab00418aa3d8a83f1eaa4511b6))
 
 ## 1.0.0 (2026-01-28)
 
 ### ✨ Features
 
-* use release branch pattern for dist folder ([b0b620a](https://github.com/ddnetters/stringray/commit/b0b620a7a92ae9d5c75636585b29f05c17e5ae78))
+* use release branch pattern for dist folder ([b0b620a](https://github.com/ddnetters/stringly-typed/commit/b0b620a7a92ae9d5c75636585b29f05c17e5ae78))
 
 ### 🔧 Maintenance
 
-* **deps:** bump langchain from 1.2.14 to 1.2.15 ([#17](https://github.com/ddnetters/stringray/issues/17)) ([8e6fb88](https://github.com/ddnetters/stringray/commit/8e6fb8836c6f9c29e9f3d0188e45fef74f210dfc))
-* **deps:** bump zod from 3.25.76 to 4.3.6 ([#16](https://github.com/ddnetters/stringray/issues/16)) ([e61af8d](https://github.com/ddnetters/stringray/commit/e61af8d07b9540c984b1b1e27c8bbc596219bb68))
-* **deps:** configure dependabot to use semver PR titles ([#15](https://github.com/ddnetters/stringray/issues/15)) ([c37215e](https://github.com/ddnetters/stringray/commit/c37215eda60a8bd421e904cc8f30bd8d4af597e1))
-* upgrade to ESLint 9 and typescript-eslint v8 ([#14](https://github.com/ddnetters/stringray/issues/14)) ([f109891](https://github.com/ddnetters/stringray/commit/f109891629eba5e0e039471d19cd360fecba9e55))
+* **deps:** bump langchain from 1.2.14 to 1.2.15 ([#17](https://github.com/ddnetters/stringly-typed/issues/17)) ([8e6fb88](https://github.com/ddnetters/stringly-typed/commit/8e6fb8836c6f9c29e9f3d0188e45fef74f210dfc))
+* **deps:** bump zod from 3.25.76 to 4.3.6 ([#16](https://github.com/ddnetters/stringly-typed/issues/16)) ([e61af8d](https://github.com/ddnetters/stringly-typed/commit/e61af8d07b9540c984b1b1e27c8bbc596219bb68))
+* **deps:** configure dependabot to use semver PR titles ([#15](https://github.com/ddnetters/stringly-typed/issues/15)) ([c37215e](https://github.com/ddnetters/stringly-typed/commit/c37215eda60a8bd421e904cc8f30bd8d4af597e1))
+* upgrade to ESLint 9 and typescript-eslint v8 ([#14](https://github.com/ddnetters/stringly-typed/issues/14)) ([f109891](https://github.com/ddnetters/stringly-typed/commit/f109891629eba5e0e039471d19cd360fecba9e55))
 
 ### 👷 CI/CD
 
-* add manual trigger to auto-release workflow ([c199a99](https://github.com/ddnetters/stringray/commit/c199a99dc18a9d28bde9ac2ba974e6e65e2f2cf7))
-* add semantic PR title validation ([0e8e4c3](https://github.com/ddnetters/stringray/commit/0e8e4c3862503051b68bff10a1517be107ea6ed9))
-* run semantic-release directly via npm instead of action ([795fa11](https://github.com/ddnetters/stringray/commit/795fa117f3a821829b0f4543c13bc9f750c268c1))
-* use GH_TOKEN for semantic-release to bypass branch protection ([f9bd553](https://github.com/ddnetters/stringray/commit/f9bd553a00976936012e6a2d4b5d8aae103a6c3e))
+* add manual trigger to auto-release workflow ([c199a99](https://github.com/ddnetters/stringly-typed/commit/c199a99dc18a9d28bde9ac2ba974e6e65e2f2cf7))
+* add semantic PR title validation ([0e8e4c3](https://github.com/ddnetters/stringly-typed/commit/0e8e4c3862503051b68bff10a1517be107ea6ed9))
+* run semantic-release directly via npm instead of action ([795fa11](https://github.com/ddnetters/stringly-typed/commit/795fa117f3a821829b0f4543c13bc9f750c268c1))
+* use GH_TOKEN for semantic-release to bypass branch protection ([f9bd553](https://github.com/ddnetters/stringly-typed/commit/f9bd553a00976936012e6a2d4b5d8aae103a6c3e))
 
 ## [Unreleased]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
-# 🤝 Contributing to StringRay
+# 🤝 Contributing to Stringly-Typed
 
-Thanks for your interest in StringRay! This is a hobby project, so contributions are welcome but kept simple.
+Thanks for your interest in Stringly-Typed! This is a hobby project, so contributions are welcome but kept simple.
 
 ## 🐛 Found a Bug?
 
-- Check if it's already reported in [Issues](https://github.com/ddnetters/stringray/issues)
+- Check if it's already reported in [Issues](https://github.com/ddnetters/stringly-typed/issues)
 - If not, open a new issue with:
   - What you expected vs what happened
   - Steps to reproduce
@@ -40,7 +40,7 @@ See [PR Title Convention](.github/PULL_REQUEST_TITLE_CONVENTION.md) for full det
 
 ```bash
 git clone your-fork
-cd stringray
+cd stringly-typed
 npm install
 npm test
 ```

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 StringRay Team
+Copyright (c) 2024 Stringly-Typed Team
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# 🌊 StringRay
+# 🎯 Stringly-Typed
 
 > **AI-powered brand voice validation for your codebase.**
 
-StringRay is a GitHub Action that scans your code for string literals and validates them against your brand style guide using AI. Ensure every user-facing message matches your voice and tone.
+Stringly-Typed is a GitHub Action that scans your code for string literals and validates them against your brand style guide using AI. Ensure every user-facing message matches your voice and tone.
 
 ---
 
@@ -23,10 +23,10 @@ Add `STYLE_GUIDE.md` to your repo:
 
 ### 2. Add the workflow
 
-Create `.github/workflows/stringray.yml`:
+Create `.github/workflows/stringly-typed.yml`:
 
 ```yaml
-name: StringRay
+name: Stringly-Typed
 on: [push, pull_request]
 
 jobs:
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ddnetters/stringray@v1
+      - uses: ddnetters/stringly-typed@v1
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         with:
@@ -45,14 +45,14 @@ jobs:
           decider-options: '{"minValidRatio": 0.9}'
 ```
 
-That's it. StringRay now validates every string against your brand voice.
+That's it. Stringly-Typed now validates every string against your brand voice.
 
 ---
 
 ## Example Output
 
 ```
-StringRay Results:
+Stringly-Typed Results:
 ├── src/components/Button.tsx
 │   ├── Line 12: "Click here to continue" ❌
 │   │   └── Use "Select" not "Click" (terminology)
@@ -67,7 +67,7 @@ StringRay Results:
 
 ## Other Checkers
 
-StringRay also supports non-AI checkers for simpler validation:
+Stringly-Typed also supports non-AI checkers for simpler validation:
 
 | Checker | Use Case |
 |---------|----------|
@@ -77,7 +77,7 @@ StringRay also supports non-AI checkers for simpler validation:
 
 ```yaml
 # Example: Enforce 80 character limit
-- uses: ddnetters/stringray@v1
+- uses: ddnetters/stringly-typed@v1
   with:
     checker: 'char_count'
     checker-options: '{"maxChars": 80}'
@@ -103,7 +103,7 @@ StringRay also supports non-AI checkers for simpler validation:
 
 Contributions welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
-- [Report Issues](https://github.com/ddnetters/stringray/issues)
+- [Report Issues](https://github.com/ddnetters/stringly-typed/issues)
 
 ## License
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
-# 🚀 StringRay Release Process
+# 🚀 Stringly-Typed Release Process
 
-This document outlines the release process for StringRay, including versioning, tagging, and publishing.
+This document outlines the release process for Stringly-Typed, including versioning, tagging, and publishing.
 
 ## 📋 Release Checklist
 
@@ -20,7 +20,7 @@ This document outlines the release process for StringRay, including versioning, 
 
 ## 🏷️ Versioning Strategy
 
-StringRay follows [Semantic Versioning](https://semver.org/):
+Stringly-Typed follows [Semantic Versioning](https://semver.org/):
 
 - **Major (X.0.0)**: Breaking changes to the action interface
 - **Minor (1.X.0)**: New features, backward compatible
@@ -76,7 +76,7 @@ The release process is automated via GitHub Actions:
 
 ## 📦 npm Publishing (Optional)
 
-If you want to publish StringRay as an npm package:
+If you want to publish Stringly-Typed as an npm package:
 
 ### Setup
 1. Create npm account and get auth token
@@ -85,8 +85,8 @@ If you want to publish StringRay as an npm package:
 
 ### Package Configuration
 The package will be published as:
-- **Name**: `stringray`
-- **Scope**: Could be `@ddnetters/stringray`
+- **Name**: `stringly-typed`
+- **Scope**: Could be `@ddnetters/stringly-typed`
 - **Registry**: npm public registry
 
 ## 🏗️ Manual Release Process
@@ -166,7 +166,7 @@ git push origin main
 Use this template for GitHub releases:
 
 ```markdown
-## 🌊 StringRay vX.Y.Z
+## 🎯 Stringly-Typed vX.Y.Z
 
 ### ✨ New Features
 - Feature 1 description
@@ -185,19 +185,19 @@ Use this template for GitHub releases:
 ## 🚀 Quick Start
 
 \`\`\`yaml
-- uses: ddnetters/stringray@vX.Y.Z
+- uses: ddnetters/stringly-typed@vX.Y.Z
   with:
     files: 'src/**/*.{js,ts,md}'
     checker: 'char_count'
     decider: 'threshold'
 \`\`\`
 
-**Full Changelog**: https://github.com/ddnetters/stringray/compare/vX.Y.Z-1...vX.Y.Z
+**Full Changelog**: https://github.com/ddnetters/stringly-typed/compare/vX.Y.Z-1...vX.Y.Z
 ```
 
 ## 🎯 Version Tags & Release Branches
 
-StringRay uses a **release branch pattern** to keep the main branch clean. The compiled `dist/` folder is not committed to main - instead, it's published to release branches during the release process.
+Stringly-Typed uses a **release branch pattern** to keep the main branch clean. The compiled `dist/` folder is not committed to main - instead, it's published to release branches during the release process.
 
 ### How It Works
 
@@ -211,13 +211,13 @@ StringRay uses a **release branch pattern** to keep the main branch clean. The c
 ### Usage Examples
 ```yaml
 # Use latest in major version (recommended)
-uses: ddnetters/stringray@v1
+uses: ddnetters/stringly-typed@v1
 
 # Pin to exact version (for maximum stability)
-uses: ddnetters/stringray@v1.2.3
+uses: ddnetters/stringly-typed@v1.2.3
 
 # Reference release branch directly (alternative)
-uses: ddnetters/stringray@releases/v1
+uses: ddnetters/stringly-typed@releases/v1
 ```
 
 ## 🚨 Release Rollback
@@ -255,6 +255,6 @@ Track these metrics for releases:
 ## 🤝 Questions?
 
 If you have questions about the release process:
-- Check existing [GitHub Issues](https://github.com/ddnetters/stringray/issues)
-- Create a [Discussion](https://github.com/ddnetters/stringray/discussions)
+- Check existing [GitHub Issues](https://github.com/ddnetters/stringly-typed/issues)
+- Create a [Discussion](https://github.com/ddnetters/stringly-typed/discussions)
 - Review previous releases for examples

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability in StringRay, please report it responsibly:
+If you discover a security vulnerability in Stringly-Typed, please report it responsibly:
 
 1. **Do NOT open a public issue** for security vulnerabilities
 2. Email the maintainers directly or use GitHub's private vulnerability reporting feature
@@ -24,14 +24,14 @@ We aim to respond to security reports within 48 hours and will work with you to 
 
 ### Custom Checker/Decider Logic
 
-StringRay supports custom JavaScript logic via the `custom` checker and decider types. This feature uses JavaScript's `Function` constructor to execute user-provided code.
+Stringly-Typed supports custom JavaScript logic via the `custom` checker and decider types. This feature uses JavaScript's `Function` constructor to execute user-provided code.
 
 **Important:** Only use custom logic from trusted sources. Malicious custom logic could potentially:
 - Access environment variables
 - Make network requests
 - Consume excessive resources
 
-When using StringRay in CI/CD pipelines, ensure that:
+When using Stringly-Typed in CI/CD pipelines, ensure that:
 - Custom logic configurations come from trusted, version-controlled sources
 - Pull requests modifying custom logic are carefully reviewed
 - Untrusted user input is never passed directly to custom logic configurations

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
-name: '🌊 StringRay'
-description: 'Shine a light on your code''s communication - Sonar-powered string validation for quality gates'
-author: 'StringRay Team'
+name: '🎯 Stringly-Typed'
+description: 'AI-powered brand voice validation for your codebase - String validation for quality gates'
+author: 'Stringly-Typed Team'
 inputs:
   files:
     description: 'Glob pattern for files to validate'

--- a/docs/api.md
+++ b/docs/api.md
@@ -303,7 +303,7 @@ function isAsyncChecker(checker: Checker | AsyncChecker): checker is AsyncChecke
 
 **Example:**
 ```typescript
-import { CheckerFactory, isAsyncChecker } from 'stringray';
+import { CheckerFactory, isAsyncChecker } from 'stringly-typed';
 
 const checker = CheckerFactory.createChecker('brand_style');
 
@@ -380,7 +380,7 @@ class BrandStyleChecker implements AsyncChecker {
 
 **Example:**
 ```typescript
-import { BrandStyleChecker } from 'stringray';
+import { BrandStyleChecker } from 'stringly-typed';
 
 const checker = new BrandStyleChecker();
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Validate documentation
-        uses: ddnetters/stringray@v1
+        uses: ddnetters/stringly-typed@v1
         with:
           files: 'docs/**/*.md'
           checker: 'char_count'
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Validate code strings
-        uses: ddnetters/stringray@v1
+        uses: ddnetters/stringly-typed@v1
         with:
           files: 'src/**/*.{js,ts,jsx,tsx}'
           checker: 'char_count'
@@ -170,7 +170,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Validate ${{ matrix.name }}
-        uses: ddnetters/stringray@v1
+        uses: ddnetters/stringly-typed@v1
         with:
           files: ${{ matrix.files }}
           checker: ${{ matrix.checker }}
@@ -193,7 +193,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Check for secrets
-        uses: ddnetters/stringray@v1
+        uses: ddnetters/stringly-typed@v1
         with:
           files: 'src/**/*.{js,ts,json}'
           checker: 'custom'
@@ -230,7 +230,7 @@ jobs:
             
       - name: Validate changed files
         if: steps.changed-files.outputs.any_changed == 'true'
-        uses: ddnetters/stringray@v1
+        uses: ddnetters/stringly-typed@v1
         with:
           files: ${{ steps.changed-files.outputs.all_changed_files }}
           checker: 'char_count'
@@ -256,7 +256,7 @@ jobs:
       
       # Validate component strings
       - name: Validate React components
-        uses: ddnetters/stringray@v1
+        uses: ddnetters/stringly-typed@v1
         with:
           files: 'src/components/**/*.{jsx,tsx}'
           checker: 'custom'
@@ -269,7 +269,7 @@ jobs:
           
       # Validate error messages
       - name: Validate error messages
-        uses: ddnetters/stringray@v1
+        uses: ddnetters/stringly-typed@v1
         with:
           files: 'src/utils/errors.js'
           checker: 'char_count'
@@ -277,7 +277,7 @@ jobs:
           
       # Check string lengths for UI
       - name: Check UI string lengths
-        uses: ddnetters/stringray@v1
+        uses: ddnetters/stringly-typed@v1
         with:
           files: 'src/**/*.{jsx,tsx}'
           checker: 'char_count'
@@ -305,7 +305,7 @@ jobs:
       
       # Validate main content
       - name: Validate documentation content
-        uses: ddnetters/stringray@v1
+        uses: ddnetters/stringly-typed@v1
         with:
           files: 'content/**/*.{md,mdx}'
           checker: 'char_count'
@@ -317,7 +317,7 @@ jobs:
             
       # Check heading lengths
       - name: Check heading lengths
-        uses: ddnetters/stringray@v1
+        uses: ddnetters/stringly-typed@v1
         with:
           files: 'content/**/*.md'
           checker: 'custom'
@@ -330,7 +330,7 @@ jobs:
           
       # Validate code examples
       - name: Validate code example comments
-        uses: ddnetters/stringray@v1
+        uses: ddnetters/stringly-typed@v1
         with:
           files: 'examples/**/*.js'
           checker: 'char_count'
@@ -354,7 +354,7 @@ jobs:
       - uses: actions/checkout@v3
       
       - name: Validate API descriptions
-        uses: ddnetters/stringray@v1
+        uses: ddnetters/stringly-typed@v1
         with:
           files: 'api/swagger.json'
           checker: 'custom'
@@ -374,7 +374,7 @@ Continue workflow even if validation fails:
 
 ```yaml
 - name: Validate strings (non-blocking)
-  uses: ddnetters/stringray@v1
+  uses: ddnetters/stringly-typed@v1
   continue-on-error: true
   with:
     files: 'src/**/*.js'
@@ -397,7 +397,7 @@ Report validation results to external systems:
 ```yaml
 - name: Validate strings
   id: validate
-  uses: ddnetters/stringray@v1
+  uses: ddnetters/stringly-typed@v1
   with:
     files: 'src/**/*.js'
     checker: 'char_count'
@@ -450,7 +450,7 @@ jobs:
           
       - name: Validate chunk ${{ matrix.chunk }}
         if: steps.files.outputs.files != ''
-        uses: ddnetters/stringray@v1
+        uses: ddnetters/stringly-typed@v1
         with:
           files: ${{ steps.files.outputs.files }}
           checker: 'char_count'
@@ -470,7 +470,7 @@ Validate only new or modified strings:
     key: string-validation-${{ hashFiles('src/**/*.js') }}
     
 - name: Incremental validation
-  uses: ddnetters/stringray@v1
+  uses: ddnetters/stringly-typed@v1
   with:
     files: 'src/**/*.js'
     checker: 'char_count'

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# 🌊 StringRay
+# 🎯 Stringly-Typed
 
 > **Shine a light on your code's communication.**
 
@@ -6,7 +6,7 @@ A powerful, sonar-powered GitHub Action that swims through your codebase to illu
 
 ## Overview
 
-StringRay provides a comprehensive solution for maintaining string quality across your codebase. Like underwater sonar detecting objects in the depths, StringRay scans through your files, extracts strings, validates them using configurable checkers, and makes intelligent pass/fail decisions.
+Stringly-Typed provides a comprehensive solution for maintaining string quality across your codebase. Like underwater sonar detecting objects in the depths, Stringly-Typed scans through your files, extracts strings, validates them using configurable checkers, and makes intelligent pass/fail decisions.
 
 ## Quick Start
 
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: 🔦 Scan with StringRay
-        uses: ddnetters/stringray@v1
+      - name: 🔦 Scan with Stringly-Typed
+        uses: ddnetters/stringly-typed@v1
         with:
           files: 'src/**/*.{js,ts,md}'
           checker: 'char_count'
@@ -90,8 +90,8 @@ Detect potential security issues in string literals and prevent hardcoded secret
 
 ## Support
 
-- [GitHub Issues](https://github.com/ddnetters/stringray/issues)
-- [Discussions](https://github.com/ddnetters/stringray/discussions)
+- [GitHub Issues](https://github.com/ddnetters/stringly-typed/issues)
+- [Discussions](https://github.com/ddnetters/stringly-typed/discussions)
 - [Contributing Guide](../CONTRIBUTING.md)
 
 ## License

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v3
       
       - name: Validate strings
-        uses: ddnetters/stringray@v1
+        uses: ddnetters/stringly-typed@v1
         with:
           files: 'src/**/*.{js,ts,md}'
           checker: 'char_count'
@@ -36,13 +36,13 @@ jobs:
 For production use, pin to a specific version:
 
 ```yaml
-- uses: ddnetters/stringray@v1.0.0
+- uses: ddnetters/stringly-typed@v1.0.0
 ```
 
 Or use a commit SHA for maximum security:
 
 ```yaml
-- uses: ddnetters/stringray@v1
+- uses: ddnetters/stringly-typed@v1
 ```
 
 ## Local Development
@@ -56,8 +56,8 @@ Or use a commit SHA for maximum security:
 
 ```bash
 # Clone the repository
-git clone https://github.com/ddnetters/stringray.git
-cd stringray
+git clone https://github.com/ddnetters/stringly-typed.git
+cd stringly-typed
 
 # Install dependencies
 npm install
@@ -141,7 +141,7 @@ jobs:
         with:
           node-version: '18'
       - name: Validate strings
-        uses: ddnetters/stringray@v1
+        uses: ddnetters/stringly-typed@v1
 ```
 
 ## Enterprise Setup

--- a/docs/plans/2026-01-28-pr-comments.md
+++ b/docs/plans/2026-01-28-pr-comments.md
@@ -1,0 +1,463 @@
+# PR Comments Feature Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add optional automatic PR comments that surface Stringly-Typed validation results directly in pull requests.
+
+**Architecture:** New `comment` input controls behavior (`on-failure` | `always` | `never`). A comment formatter generates markdown from `ValidatorOutput`. The action uses `@actions/github` to post/update comments on PRs.
+
+**Tech Stack:** `@actions/github` for GitHub API, existing `ValidatorOutput` types, markdown formatting.
+
+---
+
+### Task 1: Add @actions/github dependency
+
+**Files:**
+- Modify: `package.json`
+
+**Step 1: Install dependency**
+
+Run: `npm install @actions/github`
+
+**Step 2: Verify installation**
+
+Run: `npm ls @actions/github`
+Expected: `@actions/github@x.x.x`
+
+**Step 3: Commit**
+
+```bash
+git add package.json package-lock.json
+git commit -m "chore: add @actions/github for PR comments"
+```
+
+---
+
+### Task 2: Add comment input to action.yml
+
+**Files:**
+- Modify: `action.yml`
+
+**Step 1: Add the comment input**
+
+Add after `decider-options` input:
+
+```yaml
+  comment:
+    description: 'PR comment behavior: on-failure, always, or never'
+    required: false
+    default: 'on-failure'
+```
+
+**Step 2: Commit**
+
+```bash
+git add action.yml
+git commit -m "feat: add comment input to action.yml"
+```
+
+---
+
+### Task 3: Create comment formatter module
+
+**Files:**
+- Create: `src/comment-formatter.ts`
+- Create: `src/__tests__/comment-formatter.test.ts`
+
+**Step 1: Write the failing test**
+
+```typescript
+// src/__tests__/comment-formatter.test.ts
+import { formatPRComment } from '../comment-formatter';
+import { ValidatorOutput } from '../types';
+
+describe('formatPRComment', () => {
+  it('formats passing results', () => {
+    const output: ValidatorOutput = {
+      results: [
+        { file: 'src/app.ts', line: 1, start: 0, end: 10, content: 'Hello', valid: true, message: 'OK' }
+      ],
+      summary: { pass: true, reason: '1/1 strings valid (100%)' }
+    };
+
+    const comment = formatPRComment(output);
+
+    expect(comment).toContain('## 🎯 Stringly-Typed Results');
+    expect(comment).toContain('✅');
+    expect(comment).toContain('1/1 strings valid');
+  });
+
+  it('formats failing results with details', () => {
+    const output: ValidatorOutput = {
+      results: [
+        { file: 'src/app.ts', line: 5, start: 0, end: 20, content: 'Click here', valid: false, message: 'Use "Select" not "Click"' },
+        { file: 'src/app.ts', line: 10, start: 0, end: 10, content: 'Welcome', valid: true, message: 'OK' }
+      ],
+      summary: { pass: false, reason: '1/2 strings valid (50%)' }
+    };
+
+    const comment = formatPRComment(output);
+
+    expect(comment).toContain('## 🎯 Stringly-Typed Results');
+    expect(comment).toContain('❌');
+    expect(comment).toContain('src/app.ts');
+    expect(comment).toContain('Line 5');
+    expect(comment).toContain('Use "Select" not "Click"');
+  });
+
+  it('groups errors by file', () => {
+    const output: ValidatorOutput = {
+      results: [
+        { file: 'src/a.ts', line: 1, start: 0, end: 5, content: 'foo', valid: false, message: 'error 1' },
+        { file: 'src/b.ts', line: 2, start: 0, end: 5, content: 'bar', valid: false, message: 'error 2' },
+        { file: 'src/a.ts', line: 3, start: 0, end: 5, content: 'baz', valid: false, message: 'error 3' }
+      ],
+      summary: { pass: false, reason: '0/3 strings valid (0%)' }
+    };
+
+    const comment = formatPRComment(output);
+
+    // Should have file headers
+    expect(comment).toContain('`src/a.ts`');
+    expect(comment).toContain('`src/b.ts`');
+  });
+
+  it('truncates long content in output', () => {
+    const longContent = 'A'.repeat(100);
+    const output: ValidatorOutput = {
+      results: [
+        { file: 'src/app.ts', line: 1, start: 0, end: 100, content: longContent, valid: false, message: 'Too long' }
+      ],
+      summary: { pass: false, reason: '0/1 strings valid (0%)' }
+    };
+
+    const comment = formatPRComment(output);
+
+    expect(comment).not.toContain(longContent);
+    expect(comment).toContain('...');
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm test -- --testPathPattern=comment-formatter`
+Expected: FAIL - Cannot find module '../comment-formatter'
+
+**Step 3: Write the implementation**
+
+```typescript
+// src/comment-formatter.ts
+import { ValidatorOutput, ValidationResult } from './types';
+
+const MAX_CONTENT_LENGTH = 50;
+const MAX_ISSUES_PER_FILE = 5;
+const MAX_FILES = 10;
+
+function truncate(str: string, maxLength: number): string {
+  if (str.length <= maxLength) return str;
+  return str.slice(0, maxLength - 3) + '...';
+}
+
+function groupByFile(results: ValidationResult[]): Map<string, ValidationResult[]> {
+  const grouped = new Map<string, ValidationResult[]>();
+  for (const result of results) {
+    const existing = grouped.get(result.file) || [];
+    existing.push(result);
+    grouped.set(result.file, existing);
+  }
+  return grouped;
+}
+
+export function formatPRComment(output: ValidatorOutput): string {
+  const { results, summary } = output;
+  const icon = summary.pass ? '✅' : '❌';
+  const status = summary.pass ? 'Passed' : 'Failed';
+
+  let comment = `## 🎯 Stringly-Typed Results\n\n`;
+  comment += `${icon} **${status}:** ${summary.reason}\n\n`;
+
+  const invalidResults = results.filter(r => !r.valid);
+
+  if (invalidResults.length === 0) {
+    comment += `All strings passed validation.\n`;
+    return comment;
+  }
+
+  comment += `### Issues Found\n\n`;
+
+  const grouped = groupByFile(invalidResults);
+  let fileCount = 0;
+
+  for (const [file, fileResults] of grouped) {
+    if (fileCount >= MAX_FILES) {
+      const remaining = grouped.size - MAX_FILES;
+      comment += `\n*...and ${remaining} more file(s)*\n`;
+      break;
+    }
+
+    comment += `#### \`${file}\`\n\n`;
+
+    const displayResults = fileResults.slice(0, MAX_ISSUES_PER_FILE);
+    for (const result of displayResults) {
+      const content = truncate(result.content, MAX_CONTENT_LENGTH);
+      comment += `- **Line ${result.line}:** \`${content}\`\n`;
+      comment += `  - ${result.message}\n`;
+    }
+
+    if (fileResults.length > MAX_ISSUES_PER_FILE) {
+      const remaining = fileResults.length - MAX_ISSUES_PER_FILE;
+      comment += `- *...and ${remaining} more issue(s) in this file*\n`;
+    }
+
+    comment += `\n`;
+    fileCount++;
+  }
+
+  comment += `---\n*🎯 Posted by [Stringly-Typed](https://github.com/ddnetters/stringly-typed)*`;
+
+  return comment;
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `npm test -- --testPathPattern=comment-formatter`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/comment-formatter.ts src/__tests__/comment-formatter.test.ts
+git commit -m "feat: add PR comment formatter"
+```
+
+---
+
+### Task 4: Create PR commenter module
+
+**Files:**
+- Create: `src/pr-commenter.ts`
+
+**Step 1: Write the implementation**
+
+```typescript
+// src/pr-commenter.ts
+import * as github from '@actions/github';
+import * as core from '@actions/core';
+
+const COMMENT_MARKER = '<!-- stringly-typed-comment -->';
+
+export async function postOrUpdateComment(body: string): Promise<void> {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
+    core.warning('GITHUB_TOKEN not available. Skipping PR comment.');
+    return;
+  }
+
+  const context = github.context;
+
+  if (!context.payload.pull_request) {
+    core.debug('Not a pull request. Skipping comment.');
+    return;
+  }
+
+  const octokit = github.getOctokit(token);
+  const { owner, repo } = context.repo;
+  const prNumber = context.payload.pull_request.number;
+
+  const markedBody = `${COMMENT_MARKER}\n${body}`;
+
+  // Find existing Stringly-Typed comment
+  const { data: comments } = await octokit.rest.issues.listComments({
+    owner,
+    repo,
+    issue_number: prNumber
+  });
+
+  const existingComment = comments.find(c => c.body?.includes(COMMENT_MARKER));
+
+  if (existingComment) {
+    // Update existing comment
+    await octokit.rest.issues.updateComment({
+      owner,
+      repo,
+      comment_id: existingComment.id,
+      body: markedBody
+    });
+    core.info(`💬 Updated PR comment #${existingComment.id}`);
+  } else {
+    // Create new comment
+    const { data: newComment } = await octokit.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: prNumber,
+      body: markedBody
+    });
+    core.info(`💬 Created PR comment #${newComment.id}`);
+  }
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/pr-commenter.ts
+git commit -m "feat: add PR commenter module"
+```
+
+---
+
+### Task 5: Integrate commenting into action.ts
+
+**Files:**
+- Modify: `src/action.ts`
+
+**Step 1: Update action.ts**
+
+Add imports at top:
+```typescript
+import { formatPRComment } from './comment-formatter';
+import { postOrUpdateComment } from './pr-commenter';
+```
+
+Add after getting other inputs (around line 13):
+```typescript
+const commentMode = core.getInput('comment') || 'on-failure';
+```
+
+Add after setting outputs and before the pass/fail logging (around line 70):
+```typescript
+// Post PR comment if configured
+if (commentMode !== 'never') {
+  const shouldComment = commentMode === 'always' || (commentMode === 'on-failure' && !result.summary.pass);
+  if (shouldComment) {
+    const commentBody = formatPRComment(result);
+    await postOrUpdateComment(commentBody);
+  }
+}
+```
+
+**Step 2: Run full test suite**
+
+Run: `npm test`
+Expected: All tests pass
+
+**Step 3: Build and verify**
+
+Run: `npm run build`
+Expected: Successful compilation
+
+**Step 4: Commit**
+
+```bash
+git add src/action.ts
+git commit -m "feat: integrate PR commenting into action"
+```
+
+---
+
+### Task 6: Update README with comment documentation
+
+**Files:**
+- Modify: `README.md`
+
+**Step 1: Add comment input to quickstart workflow**
+
+Update the workflow example to include:
+```yaml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+```
+
+**Step 2: Add comment configuration section**
+
+Add after the "Example Output" section:
+
+```markdown
+---
+
+## PR Comments
+
+Stringly-Typed can automatically comment on pull requests with validation results.
+
+| Value | Behavior |
+|-------|----------|
+| `on-failure` | Comment only when validation fails (default) |
+| `always` | Comment on every PR run |
+| `never` | Disable PR comments |
+
+```yaml
+- uses: ddnetters/stringly-typed@v1
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  with:
+    comment: 'on-failure'
+```
+```
+
+**Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: add PR comment documentation"
+```
+
+---
+
+### Task 7: Update action.yml outputs and add GITHUB_TOKEN note
+
+**Files:**
+- Modify: `action.yml`
+
+**Step 1: Add note about GITHUB_TOKEN**
+
+Add a comment or update description to mention GITHUB_TOKEN requirement for comments.
+
+**Step 2: Commit**
+
+```bash
+git add action.yml
+git commit -m "docs: add GITHUB_TOKEN note for PR comments"
+```
+
+---
+
+### Task 8: Create draft PR
+
+**Step 1: Push branch**
+
+Run: `git push -u origin feat/pr-comments`
+
+**Step 2: Create draft PR**
+
+Run:
+```bash
+gh pr create --draft --title "feat: add optional PR comments for validation results" --body "## Summary
+- Add \`comment\` input: \`on-failure\` (default), \`always\`, \`never\`
+- Format validation results as markdown
+- Post/update comments on PRs via GitHub API
+- Requires \`GITHUB_TOKEN\` for commenting
+
+## Test plan
+- [ ] Unit tests for comment formatter
+- [ ] Manual test on a PR with failing validation
+- [ ] Manual test with \`comment: never\`
+- [ ] Verify comment updates on re-run"
+```
+
+---
+
+## Summary
+
+| Task | Description |
+|------|-------------|
+| 1 | Add @actions/github dependency |
+| 2 | Add `comment` input to action.yml |
+| 3 | Create comment formatter with tests |
+| 4 | Create PR commenter module |
+| 5 | Integrate into action.ts |
+| 6 | Update README |
+| 7 | Update action.yml with GITHUB_TOKEN note |
+| 8 | Create draft PR |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "stringray",
+  "name": "stringly-typed",
   "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "stringray",
+      "name": "stringly-typed",
       "version": "1.0.2",
       "dependencies": {
         "@actions/core": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "stringray",
+  "name": "stringly-typed",
   "version": "1.0.2",
   "author": "ddnetters",
-  "description": "🌊 StringRay - Shine a light on your code's communication. GitHub Action for string validation with sonar-like precision.",
+  "description": "🎯 Stringly-Typed - AI-powered brand voice validation for your codebase. GitHub Action for string validation with precision.",
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
## Summary

Complete rebrand from StringRay to Stringly-Typed across the entire codebase.

### Changes
- Updated package name in `package.json` and `package-lock.json`
- Updated action name and description in `action.yml`
- Updated all documentation files (README, docs/*, CONTRIBUTING, SECURITY, RELEASE, CHANGELOG)
- Updated all GitHub workflow files
- Updated GitHub issue templates and PR templates
- Renamed `test-stringray.yml` workflow to `test-stringly-typed.yml`
- Changed emoji from 🌊 to 🎯
- Updated LICENSE copyright holder

### Files Changed
- 23 files modified

## Test plan
- [ ] Verify all references to "stringray" have been replaced
- [ ] Verify GitHub Actions workflows still work
- [ ] Verify documentation links are correct