### PR TITLE
fix: preserve action.yml in release branch by saving SHA before orphan

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -65,12 +65,15 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+          # Save original commit SHA before creating orphan branch
+          ORIGINAL_SHA=$(git rev-parse HEAD)
+
           # Create orphan branch with only release files
           git checkout --orphan releases/$MAJOR_VERSION-temp
 
           # Remove everything, then add back only what's needed
           git rm -rf .
-          git checkout HEAD -- action.yml package.json README.md LICENSE 2>/dev/null || true
+          git checkout $ORIGINAL_SHA -- action.yml package.json README.md LICENSE
 
           # Add the bundled dist (force add since it's gitignored)
           git add -f dist/index.js dist/index.js.map

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,12 +117,15 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+          # Save original commit SHA before creating orphan branch
+          ORIGINAL_SHA=$(git rev-parse HEAD)
+
           # Create a clean release branch with only what's needed
           git checkout --orphan releases/$MAJOR_VERSION-temp
 
           # Remove everything, then add back only what's needed for the action
           git rm -rf .
-          git checkout HEAD -- action.yml package.json README.md LICENSE 2>/dev/null || true
+          git checkout $ORIGINAL_SHA -- action.yml package.json README.md LICENSE
 
           # Add only the bundled dist files (not the whole folder)
           git add -f dist/index.js dist/index.js.map


### PR DESCRIPTION
## Summary
- Fixes the bug causing `action.yml` to be missing from the `v1` tag/release branch
- Saves the original commit SHA before creating an orphan branch in both `release.yml` and `auto-release.yml`

## Root Cause
When creating the release branch with `git checkout --orphan`, HEAD becomes undefined. The subsequent `git checkout HEAD -- action.yml ...` command was failing silently due to `2>/dev/null || true`, causing `action.yml` and other essential files to be missing from the release.

## Fix
Save the original commit SHA before creating the orphan branch, then use that SHA to checkout the required files:
```bash
ORIGINAL_SHA=$(git rev-parse HEAD)
git checkout --orphan releases/$MAJOR_VERSION-temp
git rm -rf .
git checkout $ORIGINAL_SHA -- action.yml package.json README.md LICENSE
```

## Test plan
- [ ] Merge this PR
- [ ] Trigger a new release (e.g., a patch version bump)
- [ ] Verify the `releases/v1` branch contains `action.yml`
- [ ] Verify the `v1` tag works: `uses: ddnetters/stringly-typed@v1`

Fixes #24